### PR TITLE
Import `block_bootstrap` in `__init__.py`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ select = [
     # Pyupgrade
     "UP",
 ]
+ignore-init-module-imports = true
 
 [tool.ruff.mccabe]
 max-complexity = 18

--- a/xbootstrap/__init__.py
+++ b/xbootstrap/__init__.py
@@ -1,3 +1,6 @@
 from . import _version
+from .core import block_bootstrap
 
 __version__ = _version.get_versions()["version"]
+
+__all__ = ["block_bootstrap"]


### PR DESCRIPTION
This was removed, unnoticed, by the linter when we shifted to ruff. This PR adds it back and adds it to `__all__`.

Closes #15 